### PR TITLE
Add resources for GitHub certification to README and create recursos.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Este es un espacio abierto y comunitario para aprender a usar Git y GitHub en eq
 4. Subí tus cambios con un **pull request**
 5. Comentá, aportá, aprendé y disfrutá del proceso.
 
+## Recursos
+
+Encontrarás recursos útiles sobre certificación GitHub en el archivo [recursos.md](recursos.md).
+
 ## ¿Ideas para proyectos?
 
 Podés proponer una idea en el archivo `ideas.md`. ¡Todo suma!

--- a/recursos.md
+++ b/recursos.md
@@ -1,0 +1,29 @@
+
+# Recursos para Certificación GitHub
+
+Este documento recopila recursos útiles para prepararse para la certificación GitHub.
+
+## Enlaces importantes
+
+- **Certificación GitHub Foundations**: La página oficial para registrarse al examen de certificación.  
+  [https://examregistration.github.com/certification](https://examregistration.github.com/certification)
+
+- **Guía de Estudios**: Artículo del blog de Microsoft con orientación para preparar la certificación.  
+  [https://techcommunity.microsoft.com/blog/educatordeveloperblog/%C2%A1gu%C3%ADa-de-estudios-para-la-certificaci%C3%B3n-github-foundations/4176639](https://techcommunity.microsoft.com/blog/educatordeveloperblog/%C2%A1gu%C3%ADa-de-estudios-para-la-certificaci%C3%B3n-github-foundations/4176639)
+
+- **Manual del Examen**: Documento oficial con información sobre el formato y políticas del examen.  
+  [https://examregistration.github.com/handbook](https://examregistration.github.com/handbook)
+
+- **Guía de Estudios Gratuita**: Recurso gratuito para preparar la certificación.  
+  [aka.ms/GuiaEstudioGF](https://aka.ms/GuiaEstudioGF)
+
+- **Guía Completa en GitHub**: Repositorio con información detallada sobre la certificación.  
+  [https://github.com/LadyKerr/github-certification-guide](https://github.com/LadyKerr/github-certification-guide?tab=readme-ov-file)
+
+- **Discusión de Preparación**: Conversación comunitaria sobre la preparación para el examen.  
+  [https://github.com/orgs/community/discussions/154502#discussioncomment-12751631](https://github.com/orgs/community/discussions/154502#discussioncomment-12751631)  
+  *Nota: A la fecha de este commit, la discusión se encuentra en su segunda semana.*
+
+## Contribuciones
+
+Si conoces otros recursos útiles para la certificación GitHub, ¡no dudes en agregarlos mediante un pull request!


### PR DESCRIPTION
This pull request introduces a new section in the `README.md` file and adds a new file `recursos.md` to provide resources for GitHub certification.

### Documentation Enhancements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R18): Added a "Recursos" section with a link to the new `recursos.md` file, which provides useful resources for GitHub certification.
* [`recursos.md`](diffhunk://#diff-724f8414f4d421befee7056fc577b72deb3658f419f1785bc5134f4128e0d5a0R1-R29): Created a new file that compiles various resources, including links to the official certification page, study guides, exam handbook, and community discussions.