### PR TITLE
Enviar archivo Playlist.md generado por action a una nueva rama

### DIFF
--- a/.github/workflows/canciones.yml
+++ b/.github/workflows/canciones.yml
@@ -34,8 +34,9 @@ jobs:
 
     - name: Commit y push
       run: |
+        git checkout -B action-playlist
         git add Playlist.md
         git commit -m "🎼🎼 La Radio 🎼🎼"
-        git push origin HEAD
+        git push -f origin action-playlist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/playlist.src
+++ b/playlist.src
@@ -1,3 +1,4 @@
 Mrs. Robinson;Simon & Garfunkel
 Happy Together;The Turtles
 Contra Todos;Robe
+Dueño no tengo;Anónimo


### PR DESCRIPTION
Este PR modifica `.github/workflows/canciones.yml` para enviar el archivo `Playlist.md` generado a una nueva rama `action-playlist` que si no existe se creará. La acción se dispara ante un merge de cambios en un Pull Request que involucren a `playlist.src`. El fichero `Playlist.md` irá a `action-playlist` que, por quedar delante de `main`, provocará una nueva sugerencia de Pull Request que deberá hacerse manualmente. Una alternativa sería usar [create-pull-request](https://github.com/marketplace/actions/create-pull-request), que automatiza el envío del nuevo PR, pero requiere cambiar  permisos en el repositorio.

...Eso es lo que se espera...

Chao